### PR TITLE
Adding Go Plugin example of invoking an AWS lambda from Tyk.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Golang	| 	Pre	         | 	Checks Basic Auth creds  against an AWS DynamoDB insta
 Golang | Pre           | Custom Cache on upstream failure                            | [Link](https://gist.github.com/zalbiraw/d84ab1aef532ddc2b2ee3c6df81d836b)              
 Golang | Pre           | Request funneling until cache is built                      | [Link](https://gist.github.com/zalbiraw/b1e25dfd2132cc55a05155f4ca291e19)
 Golang | Post          | Upstream OAuth2.0 (Client credentials flow)                 | [Link](plugins/go-postauth-upstream-oauth2)
+Golang | Post          | Invoke AWS Lambda with IAM Credentials                      | [Link](plugins/go-postauth-invoke-aws-lambda)
 
 ### gRPC Plugin Languages
 

--- a/plugins/go-postauth-invoke-aws-lambda/InvokeAWSLambda.go
+++ b/plugins/go-postauth-invoke-aws-lambda/InvokeAWSLambda.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/TykTechnologies/tyk/ctx"
+	"github.com/TykTechnologies/tyk/log"
+	"github.com/TykTechnologies/tyk/user"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"net/http"
+)
+
+func InvokeLambda(rw http.ResponseWriter, r *http.Request) {
+	// Read Static AWS Configuration
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"),
+		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			"AWS_ACCESS_KEY_ID",
+			"AWS_SECRET_ACCESS_KEY",
+			"AWS_SESSION_TOKEN")),
+	)
+	if err != nil {
+		fmt.Println("Couldn't load default configuration. Have you set up your AWS account?")
+		fmt.Println(err)
+		return
+	}
+
+	// If the lambda function to be invoked is not specified in the header, execute the default
+	function := r.Header.Get("function")
+	if len(function) == 0 {
+		function = "jia_test_custom_go_plugin"
+	}
+
+	lambdaClient := lambda.NewFromConfig(cfg)
+	payload, err := json.Marshal("")
+	invokeOutput, err := lambdaClient.Invoke(context.TODO(), &lambda.InvokeInput{
+		FunctionName: aws.String(function),
+		LogType:      types.LogTypeNone,
+		Payload:      payload,
+	})
+
+	rw.WriteHeader(http.StatusOK)
+	_, err = rw.Write(invokeOutput.Payload[:])
+	if err != nil {
+		return
+	}
+
+}
+
+func main() {}
+
+func init() {
+	logger.Info("--- Go custom plugin v4 init success! ---- ")
+}

--- a/plugins/go-postauth-invoke-aws-lambda/README.md
+++ b/plugins/go-postauth-invoke-aws-lambda/README.md
@@ -1,0 +1,17 @@
+# Invoke AWS Lambda from the Tyk Gateway
+
+This plugin allows the Tyk Gateway to execut an AWS Lambda function specified from a header value.
+It requires a set of IAM credentials from AWS with execute permissions on your lambda of choice.
+
+## Configuration
+Configuration is simply done through static reference of the AWS credentials in the plugin.
+Simply replace the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` from within the plugin code.
+
+## Usage
+Supposing you have the Tyk-Gateway deployed locally on port 8081 with an API configured to execute this 
+plugin from the "post" hook, you can invoke a named lambda function `jia_test_custom_go_plugin` as follows:
+
+```shell
+curl --location 'http://localhost:8081/lambda/' \
+--header 'function: jia_test_custom_go_plugin'
+```


### PR DESCRIPTION
Adding example of invoking an AWS lambda function directly from Tyk leveraging IAM credentials. Does not require the usage of AWS API Gateway or function URLs.