### PR TITLE
Send Custom Error Messages in Golang Post Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Golang | Pre           | Request funneling until cache is built                 
 Golang | Pre           | Upstream URL rewrite based on header, query or body value   | [Link](plugins/go-header-url-rewrite-conditional)
 Golang | Post          | Upstream OAuth2.0 (Client credentials flow)                 | [Link](plugins/go-postauth-upstream-oauth2)
 Golang | Post          | Invoke AWS Lambda with IAM Credentials                      | [Link](plugins/go-postauth-invoke-aws-lambda)
+Golang | Post          | Send Custom Error Message in Plugin w/ Conditionals         | [Link](plugins/go-send-custom-error-conditional)
 Golang | Any          | Establish a connection to Redis database                      | [Link](plugins/go-connect-to-redis)
 Golang | Analytics          | Manipulate Tyk analytics records                      | [Link](plugins/go-analytics-plugins)
 

--- a/plugins/go-send-custom-error-conditional/CustomGoPlugin.go
+++ b/plugins/go-send-custom-error-conditional/CustomGoPlugin.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/TykTechnologies/tyk/header"
+	"github.com/TykTechnologies/tyk/log"
+)
+
+var logger = log.Get()
+
+// Your custom function to return the custom error message
+func ReturnError(rw http.ResponseWriter, r *http.Request) {
+
+	//your-custom-code-here
+
+	//if header value != 'foo' return function below
+	//if query param != 'x' return function below
+	//if request is going to a specific target, return the error
+	//based on our redirection rules, if request is redirected to x/y/z upstream, return the custom msg below
+
+	errorHeader := r.Header.Get("errorHeader")
+	logger.Info(fmt.Sprintf("ErrorHeader value is: %s", errorHeader))
+
+	sendErrorResponseFromMiddleware(rw, errorHeader)
+}
+
+// Custom function that contains a list of custom error messages. 
+func sendErrorResponseFromMiddleware(rw http.ResponseWriter, key string) {
+	content := map[string]interface{}{
+		"400": "This is a 400. This is also a custom error message returned from the plugin.",
+		"401": "This is a 401. This is also a custom error message returned from the plugin.",
+		"402": "This is a 402. This is also a custom error message returned from the plugin.",
+		"403": "This is a 403. This is also a custom error message returned from the plugin.",
+	}
+	if val, ok := content[key]; ok {
+
+		response := map[string]interface{}{key: val}
+
+		data, err := json.Marshal(response)
+		if err != nil {
+			return
+		}
+
+		rw.Header().Set(header.ContentType, header.ApplicationJSON)
+		errorCode, _ := strconv.Atoi(key)
+		rw.WriteHeader(errorCode)
+		rw.Write(data)
+	}
+}
+
+func main() {}
+func init() {
+	logger.Info("--- Go custom plugin v4 init success! ---- ")
+}

--- a/plugins/go-send-custom-error-conditional/README.md
+++ b/plugins/go-send-custom-error-conditional/README.md
@@ -1,0 +1,11 @@
+# Send a custom error message in a Golang function.
+
+This plugin allows the Tyk Gateway to rewrite the upstream URL of an incoming request if a header value, query parameter, or other value is present in the payload body sent in the request. If the conditional passes (storeNumber=xxxx), then include the value of the four digits in the upstream URL rewrite. For example, the incoming request is to localhost:8080/your-tyk-api/get?storeNumber=1221, the written URL is http://www.1221store.com.
+
+## Configuration
+The function `sendErrorResponseFromMiddleware` contains a map of different error codes and their custom messages. You can add as many as you like, or read them from a different file into a map. The function takes a key as an argument so that we can dynamically pull the correct error message from the map. Then, we create a new map for the response containing the key and value, which is converted into JSON using the `json.Marshal` built in Go-function. We also write the header to explicitly use application/JSON, and the body to contain the new custom error message.
+
+You can customize this to your liking, specifically by modifying the `ReturnError` function. In the case of this example, we are accepting a header that may contain a specific error code, then returning the custom error message from our map of errors. In your case, you might want to return a specific error code based on a redirect, path visited, query parameter located in the request, or other conditional. The sky is the limit.
+
+## Usage
+To be used in the post hook in your API definition. Call ReturnError as the function name, give the path for where the binary file is located on the Gateway file system, and you're off to the races.

--- a/plugins/go-send-custom-error-conditional/README.md
+++ b/plugins/go-send-custom-error-conditional/README.md
@@ -1,6 +1,6 @@
 # Send a custom error message in a Golang function.
 
-This plugin allows the Tyk Gateway to rewrite the upstream URL of an incoming request if a header value, query parameter, or other value is present in the payload body sent in the request. If the conditional passes (storeNumber=xxxx), then include the value of the four digits in the upstream URL rewrite. For example, the incoming request is to localhost:8080/your-tyk-api/get?storeNumber=1221, the written URL is http://www.1221store.com.
+This plugin allows the Gateway proxy to process a custom error message that is produced by this plugin, based on a specific condition being set. 
 
 ## Configuration
 The function `sendErrorResponseFromMiddleware` contains a map of different error codes and their custom messages. You can add as many as you like, or read them from a different file into a map. The function takes a key as an argument so that we can dynamically pull the correct error message from the map. Then, we create a new map for the response containing the key and value, which is converted into JSON using the `json.Marshal` built in Go-function. We also write the header to explicitly use application/JSON, and the body to contain the new custom error message.


### PR DESCRIPTION
# Send a custom error message in a Golang function.

This plugin allows the Gateway proxy to process a custom error message that is produced by this plugin, based on a specific condition being set. 

## Configuration
The function `sendErrorResponseFromMiddleware` contains a map of different error codes and their custom messages. You can add as many as you like, or read them from a different file into a map. The function takes a key as an argument so that we can dynamically pull the correct error message from the map. Then, we create a new map for the response containing the key and value, which is converted into JSON using the `json.Marshal` built in Go-function. We also write the header to explicitly use application/JSON, and the body to contain the new custom error message.

You can customize this to your liking, specifically by modifying the `ReturnError` function. In the case of this example, we are accepting a header that may contain a specific error code, then returning the custom error message from our map of errors. In your case, you might want to return a specific error code based on a redirect, path visited, query parameter located in the request, or other conditional. The sky is the limit.

## Usage
To be used in the post hook in your API definition. Call ReturnError as the function name, give the path for where the binary file is located on the Gateway file system, and you're off to the races.
